### PR TITLE
Bump version to 0.2.0 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prompt-groomer"
-version = "0.1.0"
+version = "0.2.0"
 description = "A lightweight Python library for optimizing and cleaning LLM inputs"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Update version in pyproject.toml from 0.1.0 to 0.2.0 to match the v0.2.0 GitHub release.

## Changes

- `pyproject.toml`: version `0.1.0` → `0.2.0`

## Next Steps

After merging this PR:
1. Ensure `PYPI_API_TOKEN` secret is configured in repository settings
2. The GitHub Actions workflow will automatically publish v0.2.0 to PyPI when manually triggered

Related: v0.2.0 release https://github.com/JacobHuang91/prompt-groomer/releases/tag/v0.2.0